### PR TITLE
Update depreciated clone URL to a supported format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,111 +1,111 @@
 [submodule "bundle/vim-rails"]
 	path = bundle/vim-rails
-	url = git://github.com/tpope/vim-rails.git
+	url = git@github.com:tpope/vim-rails.git
         ignore = dirty
 [submodule "bundle/vim-fugitive"]
 	path = bundle/vim-fugitive
-	url = git://github.com/tpope/vim-fugitive.git
+	url = git@github.com:tpope/vim-fugitive.git
         ignore = dirty
 [submodule "bundle/vim-haml"]
 	path = bundle/vim-haml
-	url = git://github.com/tpope/vim-haml.git
+	url = git@github.com:tpope/vim-haml.git
         ignore = dirty
 [submodule "bundle/vim-surround"]
 	path = bundle/vim-surround
-	url = git://github.com/tpope/vim-surround.git
+	url = git@github.com:tpope/vim-surround.git
         ignore = dirty
 [submodule "bundle/vim-endwise"]
 	path = bundle/vim-endwise
-	url = git://github.com/tpope/vim-endwise.git
+	url = git@github.com:tpope/vim-endwise.git
         ignore = dirty
 [submodule "bundle/vim-commentary"]
 	path = bundle/vim-commentary
-	url = git://github.com/tpope/vim-commentary.git
+	url = git@github.com:tpope/vim-commentary.git
         ignore = dirty
 [submodule "bundle/vim-cucumber"]
 	path = bundle/vim-cucumber
-	url = git://github.com/tpope/vim-cucumber.git
+	url = git@github.com:tpope/vim-cucumber.git
         ignore = dirty
 [submodule "bundle/nerdtree"]
 	path = bundle/nerdtree
-	url = git://github.com/scrooloose/nerdtree.git
+	url = git@github.com:scrooloose/nerdtree.git
         ignore = dirty
 [submodule "bundle/bufexplorer"]
 	path = bundle/bufexplorer
-	url = git://github.com/corntrace/bufexplorer.git
+	url = git@github.com:corntrace/bufexplorer.git
         ignore = dirty
 [submodule "bundle/supertab"]
 	path = bundle/supertab
-	url = git://github.com/ervandew/supertab.git
+	url = git@github.com:ervandew/supertab.git
         ignore = dirty
 [submodule "bundle/vim-ruby"]
 	path = bundle/vim-ruby
-	url = git://github.com/vim-ruby/vim-ruby.git
+	url = git@github.com:vim-ruby/vim-ruby.git
         ignore = dirty
 [submodule "bundle/ack.vim"]
 	path = bundle/ack.vim
-	url = git://github.com/mileszs/ack.vim.git
+	url = git@github.com:mileszs/ack.vim.git
         ignore = dirty
 [submodule "bundle/vim-colors-solarized"]
 	path = bundle/vim-colors-solarized
-	url = git://github.com/altercation/vim-colors-solarized.git
+	url = git@github.com:altercation/vim-colors-solarized.git
         ignore = dirty
 [submodule "bundle/ctrlp.vim"]
 	path = bundle/ctrlp.vim
-	url = https://github.com/kien/ctrlp.vim
+	url = git@github.com:kien/ctrlp.vim
         ignore = dirty
 [submodule "bundle/vimux"]
 	path = bundle/vimux
-	url = https://github.com/benmills/vimux
+	url = git@github.com:benmills/vimux
         ignore = dirty
 [submodule "bundle/vim-vroom"]
 	path = bundle/vim-vroom
-	url = git://github.com/skalnik/vim-vroom.git
+	url = git@github.com:skalnik/vim-vroom.git
 [submodule "bundle/vim-rake"]
 	path = bundle/vim-rake
-	url = git://github.com/tpope/vim-rake.git
+	url = git@github.com:tpope/vim-rake.git
 [submodule "bundle/vim-easymotion"]
 	path = bundle/vim-easymotion
-	url = git://github.com/Lokaltog/vim-easymotion.git
+	url = git@github.com:Lokaltog/vim-easymotion.git
 [submodule "bundle/vim-bundler"]
 	path = bundle/vim-bundler
-	url = git://github.com/tpope/vim-bundler.git
+	url = git@github.com:tpope/vim-bundler.git
 [submodule "bundle/vim-pathogen"]
 	path = bundle/vim-pathogen
-	url = git://github.com/tpope/vim-pathogen
+	url = git@github.com:tpope/vim-pathogen
 [submodule "bundle/snipmate.vim"]
 	path = bundle/snipmate.vim
-	url = git://github.com/dalibor/snipmate.vim.git
+	url = git@github.com:dalibor/snipmate.vim.git
 [submodule "snippets"]
 	path = snippets
-	url = git://github.com/dalibor/snipmate-snippets.git
+	url = git@github.com:dalibor/snipmate-snippets.git
 [submodule "bundle/vim-ragtag"]
 	path = bundle/vim-ragtag
-	url = git://github.com/tpope/vim-ragtag.git
+	url = git@github.com:tpope/vim-ragtag.git
 [submodule "bundle/vim-javascript"]
 	path = bundle/vim-javascript
-	url = git://github.com/pangloss/vim-javascript.git
+	url = git@github.com:pangloss/vim-javascript.git
 [submodule "bundle/javascript-libraries-syntax.vim"]
 	path = bundle/javascript-libraries-syntax.vim
-	url = git://github.com/othree/javascript-libraries-syntax.vim
+	url = git@github.com:othree/javascript-libraries-syntax.vim
 [submodule "bundle/tabular"]
 	path = bundle/tabular
-	url = https://github.com/godlygeek/tabular.git
+	url = git@github.com:godlygeek/tabular.git
 [submodule "bundle/vim-markdown"]
 	path = bundle/vim-markdown
-	url = git://github.com/tpope/vim-markdown.git
+	url = git@github.com:tpope/vim-markdown.git
 [submodule "bundle/file-line"]
 	path = bundle/file-line
-	url = git://github.com/bogado/file-line
+	url = git@github.com:bogado/file-line
 [submodule "bundle/vim-puppet"]
 	path = bundle/vim-puppet
-	url = git://github.com/rodjek/vim-puppet.git
+	url = git@github.com:rodjek/vim-puppet.git
 [submodule "bundle/Dockerfile.vim"]
 	path = bundle/Dockerfile.vim
-	url = git://github.com/ekalinin/Dockerfile.vim.git
+	url = git@github.com:ekalinin/Dockerfile.vim.git
 [submodule "bundle/vim-go"]
 	path = bundle/vim-go
-	url = https://github.com/fatih/vim-go.git
+	url = git@github.com:fatih/vim-go.git
 [submodule "bundle/editorconfig-vim"]
 	path = bundle/editorconfig-vim
-	url = https://github.com/editorconfig/editorconfig-vim.git
+	url = git@github.com:editorconfig/editorconfig-vim.git

--- a/colors/solarized.vim
+++ b/colors/solarized.vim
@@ -48,10 +48,10 @@
 " 2.  Next, move or clone the `vim-colors-solarized` directory so that it is
 "     a subdirectory of the `.vim/bundle` directory.
 "
-"     a. **clone with git:**
+"     a. **clone with ssh**
 "
 "       $ cd ~/.vim/bundle
-"       $ git clone git://github.com/altercation/vim-colors-solarized.git
+"       $ git clone git@github.com:altercation/vim-colors-solarized.git
 "
 "     b. **or move manually into the pathogen bundle directory:**
 "         In the parent directory of vim-colors-solarized:


### PR DESCRIPTION
Reference: https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting

Also see https://github.com/dalibor/snipmate.vim/pulls for dependency update.