### PR TITLE
Consistent clipboard behaviour on mac and linux

### DIFF
--- a/gvimrc
+++ b/gvimrc
@@ -1,3 +1,10 @@
 "When the GUI starts, t_vb is reset to its default value.
 "Reassert that no flash or beep is wanted.
 set visualbell t_vb=
+
+if has("autocmd") && has("gui")
+  au GUIEnter * set t_vb=
+endif
+
+" Turn off toolbar
+set guioptions-=T

--- a/vimrc
+++ b/vimrc
@@ -17,8 +17,9 @@ filetype plugin indent on
 " Break away from old vi compatibility
 set nocompatible
 
-" Use X11 clipboard for yank and paste
-set clipboard=unnamed
+" Cross-platform clipboard config for yank and paste
+" https://stackoverflow.com/a/30691754
+set clipboard^=unnamed,unnamedplus
 
 " Change the mapleader from \ to ,
 let mapleader = ","

--- a/vimrc
+++ b/vimrc
@@ -607,3 +607,6 @@ vnoremap <Leader>h y:call ViewHtmlText(@@)<CR>
 " View text for URL from clipboard.
 " On Linux, use @* for current selection or @+ for text in clipboard.
 nnoremap <Leader>h :call ViewHtmlText(@+)<CR>
+
+" Disable markdown recommended style
+let g:markdown_recommended_style = 0

--- a/vimrc
+++ b/vimrc
@@ -18,7 +18,7 @@ filetype plugin indent on
 set nocompatible
 
 " Use X11 clipboard for yank and paste
-set clipboard=unnamedplus
+set clipboard=unnamed
 
 " Change the mapleader from \ to ,
 let mapleader = ","
@@ -62,13 +62,9 @@ set linespace=4
 " Disable visual bell
 set visualbell t_vb=
 
-" Gvim
-if has("autocmd") && has("gui")
-  au GUIEnter * set t_vb=
-endif
-
-" Turn off toolbar on GVim
-set guioptions-=T
+" Fix slow long lines
+set synmaxcol=750
+set maxmempattern=10000
 
 " Store temporary files in a central spot
 set backupdir=~/.vim-tmp,~/.tmp,~/tmp,/var/tmp,/tmp
@@ -124,6 +120,9 @@ set colorcolumn=81
 " https://github.com/vim/vim/issues/1671
 set term=gnome-256color
 
+" Set displayed encoding
+set encoding=utf-8
+
 " Colorscheme
 if has("gui_running")
   " Tell the term has 256 colors
@@ -147,7 +146,7 @@ else
 endif
 
 " Use Ack instead of grep
-let g:ackprg="ack-grep -H --nocolor --nogroup --column"
+let g:ackprg="ack -H --nocolor --nogroup --column"
 set grepprg=ack
 
 
@@ -221,6 +220,10 @@ nmap <leader>bD :bufdo bd<cr>
 
 " Clear the search buffer when hitting return
 :nnoremap <cr> :nohlsearch<cr>
+
+" Copy current file path
+" https://stackoverflow.com/questions/916875/yank-file-name-path-of-current-buffer-in-vim
+:nmap <leader>cp :let @+ = expand("%")<cr>
 
 " xnoremap - mappings should apply to Visual mode, but not to Select mode
 xnoremap * :<c-u>call <SID>VSetSearch()<cr>/<c-R>=@/<cr><cr>
@@ -342,6 +345,7 @@ let NERDTreeWinPos = "left"
 let NERDTreeHijackNetrw = 1
 "let NERDTreeQuitOnOpen = 1
 let NERDTreeWinSize = 40
+let g:NERDTreeDirArrows=0
 map <leader>p :NERDTreeToggle<cr>
 " Open NERDTree by default
 "autocmd VimEnter * NERDTree


### PR DESCRIPTION
- Consistent clipboard behaviour on mac and linux
- Disable markdown recommended style
- Few other tweaks